### PR TITLE
Allow "_(" term ")" in the input syntax to request type inference

### DIFF
--- a/src-lib/PTS/Parser.hs
+++ b/src-lib/PTS/Parser.hs
@@ -38,7 +38,7 @@ natop n f x = mkNatOp n f <$> (keyword (show n) *> x) <*> (x <?> "second argumen
 
 expr = term simple rec mkPos "expression" where
   simple = withPos mkPos $ asum
-    [ parens expr
+    [ termParens expr
     , brackets expr
     , abs mkLam lambda identOrMeta colon1 expr dot expr
     , abs mkPi  pi     identOrMeta colon1 expr dot expr
@@ -152,9 +152,11 @@ assign = lexem (char '=')
 semi   = lexem (char ';')
 arrow  = lexem (string "->")
 
+termParens p = parens p <|> underscore_lparen *> p <* rparen
 parens p   = lparen *> p <* rparen
 brackets p = lbracket *> p <* rbracket
 
+underscore_lparen = lexem(keyword "_(")
 lparen = lexem(char '(')
 rparen = lexem(char ')')
 lbracket = lexem(char '[')


### PR DESCRIPTION
The goal is to allow pretty-printing such subexpressions as simple
underscores (or maybe as nothing, who knows?) for extra readability in LaTeX
output.

However, don't change `parens`, since it is used in too many places. Changing
`parens` would additionally allow things like:

f _(a b : type) ...

instead of

f (a b : type) ...

so add the _( ) syntax only to a variant of `parens` (which reuses the old code).
