### PR TITLE
Fix #9: try expressions first, backtrack to definitions 

### DIFF
--- a/src-lib/PTS/Parser.hs
+++ b/src-lib/PTS/Parser.hs
@@ -63,8 +63,8 @@ unquote = char '$' *> asum
   , parens expr]
 
 stmt = withPos StmtPos $ asum
-  [ try (Bind <$> ident <*> args <*> optionMaybe (colon1 *> expr) <* assign <*> expr <* semi)
-  , Term <$> expr <* semi]
+  [ try (Term <$> expr <* semi)
+  , Bind <$> ident <*> args <*> optionMaybe (colon1 *> expr) <* assign <*> expr <* semi]
 
 stmts = many (optional pragma *> stmt)
 


### PR DESCRIPTION
Before this fix:

```
test.pts:1: Syntax Error

  foo : * = Pi T . T;
      ^
  unexpected ":"
  expecting "(", "[", "lambda", "Lambda", "Pi", "if0", "add", "sub", "mul", "div", constant, "$", variable name, "->" or ";"
```

After this fix:

```
test.pts:1: Syntax Error

  foo : * = Pi T . T;
                 ^
  unexpected "."
  expecting ":"
```

At some point during the fixing I had fixed the above, but broken just about everything else.

To be sure I didn't do that again, I tested this on existing code with:

```
$ cabal build && dist/build/pts/pts -l ../tsr-experiments/partial-evaluation.lfos && dist/build/pts/pts -l ../tsr-experiments/system-f.lfo && dist/build/pts/pts test.pts
```

Given the nature of the change, this should be enough, but it'd be nice to have better tests.

Also, as detailed in the last commit, this might make error messages worse for expressions, since they're tried first. I also argue there why that's a reasonable tradeoff.

The commit messages are crazily long because they explain why the changes affect the parsing results, and that simply can't be done without accounting for backtracking.
