### PR TITLE
Stop relying on Show for terms

### DIFF
--- a/pts.cabal
+++ b/pts.cabal
@@ -98,6 +98,7 @@ Test-suite tests
   Other-modules:       PTS.Core.Properties
                        PTS.Core.Tests
                        PTS.File.Tests
+                       PTS.PrettyToShow
                        PTS.Syntax.Arbitrary
                        PTS.Syntax.Parser.Tests
                        PTS.Syntax.Pretty.Tests

--- a/src-lib/PTS/Process/File.hs
+++ b/src-lib/PTS/Process/File.hs
@@ -180,16 +180,16 @@ processStmt (Import mod) = recover () $ do
 
       case result of
         Nothing ->
-          fail $ "expected module " ++ show mod ++ " in file " ++ file ++ " but found no module statement."
+          fail $ "expected module " ++ showPretty mod ++ " in file " ++ file ++ " but found no module statement."
         Just (Module _ name _) | name /= mod ->
-          fail $ "expected module " ++ show mod ++ " inf file " ++ file ++ " but found module " ++ show name ++ "."
+          fail $ "expected module " ++ showPretty mod ++ " inf file " ++ file ++ " but found module " ++ showPretty name ++ "."
         Just found@(Module _ _ bindings') ->
           put (Map.insert mod found cache, imports, bindings ++ bindings')
 
 findModule path mod = find path where
   base  =  joinPath (parts mod)
 
-  find [] = fail ("source file for module " ++ show mod ++ " not found.")
+  find [] = fail ("source file for module " ++ showPretty mod ++ " not found.")
   find (dir : path) = do
     let lpts  = dir </> base <.> "lpts"
     let pts   = dir </> base <.> "pts"

--- a/src-lib/PTS/Statics/Typing.hs
+++ b/src-lib/PTS/Statics/Typing.hs
@@ -99,10 +99,10 @@ debug n t result = do
   enter n
   ctx <- getEnvironment
   -- log $ "Context: " ++ showCtx [(n, (x, y)) | (n, (_, x, y)) <- ctx]
-  log $ "Subject: " ++ show t
+  log $ "Subject: " ++ showPretty t
   x <- result
-  log $ "Result:  " ++ show x
-  log $ "         : " ++ show (typeOf x)
+  log $ "Result:  " ++ showPretty x
+  log $ "         : " ++ showPretty (typeOf x)
   exit
   return x
 
@@ -111,11 +111,11 @@ debugPush n t q result = do
   enter n
   ctx <- getEnvironment
   log $ "Context: " ++ showCtx [(n, (x, y)) | (n, (_, x, y)) <- ctx]
-  log $ "Subject: " ++ show t
-  log $ "Push type: " ++ show q
+  log $ "Subject: " ++ showPretty t
+  log $ "Push type: " ++ showPretty q
   x <- result
-  log $ "Result:  " ++ show x
-  log $ "         : " ++ show (typeOf x)
+  log $ "Result:  " ++ showPretty x
+  log $ "         : " ++ showPretty (typeOf x)
   exit
   return x
 

--- a/src-lib/PTS/Syntax.hs
+++ b/src-lib/PTS/Syntax.hs
@@ -61,6 +61,7 @@ module PTS.Syntax
   , Pretty (pretty)
   , singleLine
   , multiLine
+  , showPretty
   , showCtx
   , showAssertion
     -- * Operations

--- a/src-lib/PTS/Syntax/Pretty.hs
+++ b/src-lib/PTS/Syntax/Pretty.hs
@@ -6,6 +6,7 @@ module PTS.Syntax.Pretty
   , showCtx
   , prettyAlgebra
   , showAssertion
+  , showPretty
   ) where
 
 import Control.Arrow (first)
@@ -175,14 +176,8 @@ showAssertion t q' t' = singleLine (prettyAssertion t q' t')
 instance Pretty ModuleName where
   pretty p m = text (intercalate "." (parts m))
 
-instance Show Term where
-  show t = singleLine t
-
-instance Show TypedTerm where
-  show t = singleLine t
-
-instance Show ModuleName where
-  show t = singleLine t
+showPretty :: Pretty p => p -> String
+showPretty = singleLine
 
 showCtx :: [(Name, (a, TypedTerm))] -> String
-showCtx = concat . intersperse ", " . map (\(n, (v, t)) -> show n ++ " : " ++ show t)
+showCtx = concat . intersperse ", " . map (\(n, (v, t)) -> show n ++ " : " ++ showPretty t)

--- a/src-test/PTS/Core/Properties.hs
+++ b/src-test/PTS/Core/Properties.hs
@@ -8,6 +8,7 @@ import PTS.Syntax
 import PTS.Syntax.Arbitrary
 import PTS.Statics
 import PTS.Dynamics
+import PTS.PrettyToShow
 
 type Relation a = a -> a -> Bool
 

--- a/src-test/PTS/PrettyToShow.hs
+++ b/src-test/PTS/PrettyToShow.hs
@@ -1,0 +1,6 @@
+module PTS.PrettyToShow where
+
+import PTS.Syntax
+
+instance Show Term where
+  show a = showPretty a

--- a/src-test/PTS/Syntax/Parser/Tests.hs
+++ b/src-test/PTS/Syntax/Parser/Tests.hs
@@ -10,7 +10,7 @@ import PTS.Syntax
 parse text = parseTerm "PTS.Syntax.Parser.Tests" text :: Either [PTSError] PTS.Syntax.Term
 
 testParser text term = testCase text $ case parse text of
-  Right parsedTerm ->  assertEqual "Unexpected parse result." (show term) (show parsedTerm)
+  Right parsedTerm ->  assertEqual "Unexpected parse result." (showPretty term) (showPretty parsedTerm)
   Left error -> assertFailure $ "Unexpected parse error: " ++ show error
 
 x :: Name

--- a/src-test/PTS/Syntax/Pretty/Tests.hs
+++ b/src-test/PTS/Syntax/Pretty/Tests.hs
@@ -21,7 +21,7 @@ z = read "z"
 
 testPretty text term
   =  testCase text $
-       assertEqual "Unexpected pretty print." text (show term)
+       assertEqual "Unexpected pretty print." text (showPretty term)
 
 tests
   =  testGroup "PTS.Pretty"

--- a/src-test/PTS/Syntax/Substitution/Tests.hs
+++ b/src-test/PTS/Syntax/Substitution/Tests.hs
@@ -8,6 +8,7 @@ import Test.HUnit (assertBool)
 import PTS.Syntax
 import PTS.Instances
 import qualified PTS.Syntax.Substitution.Properties as Prop
+import PTS.PrettyToShow
 
 import Test.Property (test)
 


### PR DESCRIPTION
Instead, use prettyShow, a new alias for singleLine (whose name is
questionable anyway).

This will allow adding 'deriving Show' for use in development.

We still create a Show instance based on pretty printing in some tests;
arguably they should switch to this future Show instance, to show all
nitty-gritty details of the inputs triggering failures.
