### PR TITLE
Remove redundant Name from IntOp nodes

### DIFF
--- a/src-lib/PTS/Dynamics/Evaluation.hs
+++ b/src-lib/PTS/Dynamics/Evaluation.hs
@@ -51,7 +51,7 @@ equiv (PiType n v1 (ValueFunction f)) (PiType _ v1' (ValueFunction f')) = do
   v2'  <- f'  (ResidualVar n')
   r2   <- equiv v2 v2'
   return (r1 && r2)
-equiv (ResidualIntOp n op v1 v2) (ResidualIntOp n' op' v1' v2') = do
+equiv (ResidualIntOp op v1 v2) (ResidualIntOp op' v1' v2') = do
   let r1 = op == op'
   r2 <- equiv v1 v1'
   r3 <- equiv v2 v2'
@@ -101,10 +101,10 @@ reify (PiType n v1 (ValueFunction f)) = do
   v2 <- f (ResidualVar n')
   e2 <- reify v2
   return (mkPi n' e1 e2)
-reify (ResidualIntOp n op v1 v2) = do
+reify (ResidualIntOp op v1 v2) = do
   e1 <- reify v1
   e2 <- reify v2
-  return (mkIntOp n op e1 e2)
+  return (mkIntOp op e1 e2)
 reify (ResidualIfZero v1 v2 v3) = do
   e1 <- reify v1
   e2 <- reify v2
@@ -127,11 +127,11 @@ eval :: Term -> Env Eval -> Eval (Value Eval)
 eval t env = case structure t of
   Int n -> do
     return (Number n)
-  IntOp n op e1 e2 -> do
+  IntOp op e1 e2 -> do
     v1 <- eval e1 env
     v2 <- eval e2 env
     return $
-      fromMaybe (ResidualIntOp n op v1 v2)
+      fromMaybe (ResidualIntOp op v1 v2)
         (case (v1, v2) of
             (Number n1, Number n2) -> do
               Number <$> evalOp op n1 n2
@@ -175,7 +175,7 @@ eval t env = case structure t of
 {-
 data TermStructure alpha
   = Int     Integer
-  | IntOp   Name BinOp alpha alpha
+  | IntOp   BinOp alpha alpha
   | IfZero  alpha alpha alpha
   | Var     Name
   | Const   C

--- a/src-lib/PTS/Dynamics/Value.hs
+++ b/src-lib/PTS/Dynamics/Value.hs
@@ -13,7 +13,7 @@ data Value m
   | Number    Integer
   | Constant  C
   | PiType    Name (Value m) (ValueFunction m)
-  | ResidualIntOp  Name BinOp (Value m) (Value m)
+  | ResidualIntOp  BinOp (Value m) (Value m)
   | ResidualIfZero (Value m) (Value m) (Value m)
   | ResidualVar    Name
   | ResidualApp    (Value m) (Value m)

--- a/src-lib/PTS/QuasiQuote.hs
+++ b/src-lib/PTS/QuasiQuote.hs
@@ -88,7 +88,7 @@ instance Lift Name where
 
 instance Lift Term where
   lift (MkTerm (Int     n))              =  con 'MkTerm  [con 'Int     [lift n]]
-  lift (MkTerm (IntOp   v  op  e1  e2))  =  con 'MkTerm  [con 'IntOp   [lift v,  lift op,  lift e1,  lift e2]]
+  lift (MkTerm (IntOp   op  e1  e2))     =  con 'MkTerm  [con 'IntOp   [lift op,  lift e1,  lift e2]]
   lift (MkTerm (IfZero  c  t   e))       =  con 'MkTerm  [con 'IfZero  [lift c,  lift t,   lift e]]
   lift (MkTerm (Var     v))              =  con 'MkTerm  [con 'Var     [lift v]]
   lift (MkTerm (Const   c))              =  con 'MkTerm  [con 'Const   [lift c]]

--- a/src-lib/PTS/Statics/Typing.hs
+++ b/src-lib/PTS/Statics/Typing.hs
@@ -286,12 +286,12 @@ typecheckPull t = case structure t of
     return (MkTypedTerm (Int i) int')
 
   -- IntOp
-  IntOp opName opFunction t1 t2 -> debug "typecheckPull IntOp" t $ do
+  IntOp opFunction t1 t2 -> debug "typecheckPull IntOp" t $ do
     integerType <- typecheckPull (mkConst int)
     -- Both arguments to any IntOp have to be Ints, so typecheckPush an Int in there.
     t1'@(MkTypedTerm _ tt1) <- typecheckPush t1 integerType
     t2'@(MkTypedTerm _ tt2) <- typecheckPush t2 integerType
-    return (MkTypedTerm (IntOp opName opFunction t1' t2') integerType)
+    return (MkTypedTerm (IntOp opFunction t1' t2') integerType)
 
   -- IfZero
   IfZero condition thenTerm elseTerm -> debug "typecheckPull IfZero" t $ do
@@ -419,12 +419,12 @@ typecheckPush t q = case structure t of
     return (MkTypedTerm (Int i) int')
 
   -- IntOp
-  IntOp opName opFunction t1 t2 -> debugPush "typecheckPush IntOp" t q $ do
+  IntOp opFunction t1 t2 -> debugPush "typecheckPush IntOp" t q $ do
     integerType <- typecheckPull (mkConst int)
     bidiExpected integerType q t "An integer operation is not expected to be one."
     typedT1 <- typecheckPush t1 integerType
     typedT2 <- typecheckPush t2 integerType
-    return (MkTypedTerm (IntOp opName opFunction typedT1 typedT2) integerType)
+    return (MkTypedTerm (IntOp opFunction typedT1 typedT2) integerType)
 
   -- IfZero
   IfZero t1 t2 t3 -> debugPush "typecheckPush IfZero" t q $ do

--- a/src-lib/PTS/Syntax/Algebra.hs
+++ b/src-lib/PTS/Syntax/Algebra.hs
@@ -36,7 +36,7 @@ allvars t = fold allvarsAlgebra t
 allvarsAlgebra :: Algebra Names
 allvarsAlgebra (Var x)            =  Set.singleton x
 allvarsAlgebra (App t1 t2)        =  t1 `Set.union` t2
-allvarsAlgebra (IntOp _ _ t1 t2)  =  t1 `Set.union` t2
+allvarsAlgebra (IntOp _ t1 t2)    =  t1 `Set.union` t2
 allvarsAlgebra (IfZero t1 t2 t3)  =  t1 `Set.union` t2 `Set.union` t3
 allvarsAlgebra (Lam x t1 t2)      =  Set.insert x (t1 `Set.union` t2)
 allvarsAlgebra (Pi x t1 t2)       =  Set.insert x (t1 `Set.union` t2)
@@ -47,7 +47,7 @@ freevarsAlgebra :: Algebra Names
 freevarsAlgebra t = case t of
   Var x            ->  Set.singleton x
   App t1 t2        ->  t1 `Set.union` t2
-  IntOp _ _ t1 t2  ->  t1 `Set.union` t2
+  IntOp _ t1 t2    ->  t1 `Set.union` t2
   IfZero t1 t2 t3  ->  Set.unions [t1, t2, t3]
   Lam x t1 t2      ->  t1 `Set.union` (Set.delete x t2)
   Pi x t1 t2       ->  t1 `Set.union` (Set.delete x t2)

--- a/src-lib/PTS/Syntax/Diff.hs
+++ b/src-lib/PTS/Syntax/Diff.hs
@@ -12,7 +12,7 @@ import PTS.Syntax.Substitution (freshCommonVar)
 data Diff
   = DEqual Term
   | DDifferent Term Term
-  | DIntOp Name Diff Diff
+  | DIntOp BinOp Diff Diff
   | DIfZero Diff Diff Diff
   | DApp Diff Diff
   | DLam Name Diff Diff
@@ -29,9 +29,9 @@ diff t1 t2 = case (structure t1, structure t2) of
     |   n1 == n2   ->  DEqual t1
     |   otherwise  ->  DDifferent t1 t2
 
-  (IntOp n1 _ x1 y1, IntOp n2 _ x2 y2)
-    |   n1 == n2   ->  let x = diff x1 x2; y = diff y1 y2 in
-                         if allEqual [x, y] then DEqual t1 else DIntOp n1 x y
+  (IntOp op1 x1 y1, IntOp op2 x2 y2)
+    |   op1 == op2 ->  let x = diff x1 x2; y = diff y1 y2 in
+                         if allEqual [x, y] then DEqual t1 else DIntOp op1 x y
     |   otherwise  ->  DDifferent t1 t2
 
   (IfZero n1 x1 y1, IfZero n2 x2 y2)

--- a/src-lib/PTS/Syntax/Parser.hs
+++ b/src-lib/PTS/Syntax/Parser.hs
@@ -61,7 +61,7 @@ setPos f p1 x p2 = f (Position (sourceName p1) (sourceLine p1) (sourceLine p2) (
     -- PTS PARSER --
      -----------------
 
-intop n f x = mkIntOp n f <$> (keyword (show n) *> x) <*> (x <?> "second argument of '" ++ show n ++ "'")
+intop n f x = mkIntOp f <$> (keyword n *> x) <*> (x <?> "second argument of '" ++ n ++ "'")
 
 expr = term simple rec mkPos "expression" where
   simple = withPos mkPos $ asum
@@ -74,10 +74,10 @@ expr = term simple rec mkPos "expression" where
     , mkIfZero <$> (keyword "if0" *> expr)
              <*> (keyword "then" *> expr)
              <*> (keyword "else" *> expr)
-    , intop (read "add") Add simple
-    , intop (read "sub") Sub simple
-    , intop (read "mul") Mul simple
-    , intop (read "div") Div simple
+    , intop "add" Add simple
+    , intop "sub" Sub simple
+    , intop "mul" Mul simple
+    , intop "div" Div simple
     , mkConst <$> const
     , mkUnquote <$> unquote
     , mkInfer <$> infer

--- a/src-lib/PTS/Syntax/Pretty.hs
+++ b/src-lib/PTS/Syntax/Pretty.hs
@@ -66,6 +66,12 @@ data PrettyChain
   | Atomic Doc
   | Composite Priority Doc
 
+instance Pretty BinOp where
+  pretty _ Add = text "add"
+  pretty _ Sub = text "sub"
+  pretty _ Mul = text "mul"
+  pretty _ Div = text "div"
+
 type Priority = Int
 
 instance Pretty PrettyChain where
@@ -99,7 +105,7 @@ prettyAlgebra :: PreAlgebra (Names, PrettyChain) PrettyChain
 prettyAlgebra (Int n) = Atomic $
   integer n
 
-prettyAlgebra (IntOp n _ (_, a) (_, b)) = Composite pApp $
+prettyAlgebra (IntOp n (_, a) (_, b)) = Composite pApp $
   pretty 0 n <+> pretty pAppR a <+> pretty pAppR b
 
 prettyAlgebra (IfZero (_, c) (_, t) (_, e)) = Composite pIf0 $

--- a/src-lib/PTS/Syntax/Substitution.hs
+++ b/src-lib/PTS/Syntax/Substitution.hs
@@ -40,7 +40,7 @@ avoidCapture s x y t = (x', s') where
 subst :: Term -> Name -> Term -> Term
 subst t x t' = case structure t of
   Int i                 ->  mkInt i
-  IntOp i f t1 t2       ->  mkIntOp i f (subst t1 x t') (subst t2 x t')
+  IntOp op t1 t2        ->  mkIntOp op (subst t1 x t') (subst t2 x t')
   IfZero t1 t2 t3       ->  mkIfZero (subst t1 x t') (subst t2 x t')  (subst t3 x t')
   Var y | y == x        ->  t'
   Var y | otherwise     ->  mkVar y
@@ -60,7 +60,7 @@ subst t x t' = case structure t of
 typedSubst :: TypedTerm -> Name -> TypedTerm -> TypedTerm
 typedSubst t x t' = case structure t of
   Int i                 ->  MkTypedTerm (Int i) (typeOf t)
-  IntOp i f t1 t2       ->  MkTypedTerm (IntOp i f (typedSubst t1 x t') (typedSubst t2 x t')) (typeOf t)
+  IntOp op t1 t2        ->  MkTypedTerm (IntOp op (typedSubst t1 x t') (typedSubst t2 x t')) (typeOf t)
   IfZero t1 t2 t3       ->  MkTypedTerm (IfZero (typedSubst t1 x t') (typedSubst t2 x t')  (typedSubst t3 x t')) (typeOf t)
   Var y | y == x        ->  t'
   Var y | otherwise     ->  MkTypedTerm (Var y) (typeOf t)

--- a/src-lib/PTS/Syntax/Term.hs
+++ b/src-lib/PTS/Syntax/Term.hs
@@ -95,14 +95,9 @@ evalOp Div = safeDiv
     safeDiv x 0 = Nothing
     safeDiv x y = Just $ div x y
 
--- XXX outdated.
-
--- the string in IntOp is an identifier for the function. It is necessary
--- to check equivalence of terms (the functions cannot be directly compared)
-
 data TermStructure alpha
   = Int     Integer
-  | IntOp   Name BinOp alpha alpha
+  | IntOp   BinOp alpha alpha
   | IfZero  alpha alpha alpha
   | Var     Name
   | Const   C
@@ -144,7 +139,7 @@ mkTerm t = result where
 
 -- smart constructors
 mkInt i            =  mkTerm (Int i)
-mkIntOp n f t1 t2  =  mkTerm (IntOp n f t1 t2)
+mkIntOp f t1 t2    =  mkTerm (IntOp f t1 t2)
 mkIfZero t1 t2 t3  =  mkTerm (IfZero t1 t2 t3)
 mkVar n            =  mkTerm (Var n)
 mkConst c          =  mkTerm (Const c)

--- a/src-test/PTS/Core/Tests.hs
+++ b/src-test/PTS/Core/Tests.hs
@@ -51,7 +51,7 @@ tests
         [  alphaEquivalenceReflexive
         -- ,  alphaEquivalenceSymmetric
         -- ,  alphaEquivalenceTransitive
-        ,  alphaEquivalentRefl (mkIntOp (read "div") Div (mkInt 11) (mkInt 0))
+        ,  alphaEquivalentRefl (mkIntOp Div (mkInt 11) (mkInt 0))
         ,  alphaEquivalent (mkVar x) (mkVar x)
         ,  alphaEquivalent (mkLam x (mkVar x) (mkVar x)) (mkLam y (mkVar x) (mkVar y))
         ,  alphaEquivalent (mkLam y (mkVar x) (mkVar y)) (mkLam x (mkVar x) (mkVar x))

--- a/src-test/PTS/Syntax/Arbitrary.hs
+++ b/src-test/PTS/Syntax/Arbitrary.hs
@@ -66,13 +66,13 @@ arbitraryIntOp = do
 
   t1      <-  resize s1 arbitrary
   t2      <-  resize s2 arbitrary
-  (n, f)  <-  elements
-                [  (read "add", Add)
-                ,  (read "sub", Sub)
-                ,  (read "mul", Mul)
-                ,  (read "div", Div)
+  op      <-  elements
+                [  Add
+                ,  Sub
+                ,  Mul
+                ,  Div
                 ]
-  return (mkIntOp n f t1 t2)
+  return (mkIntOp op t1 t2)
 
 arbitraryIfZero = do
   (s1, s2, s3) <- distributeSize


### PR DESCRIPTION
This name was needed when arithmetic operations were just functions, but
they were defunctionalized in 9d2adccc3308ccefa5d1215c1a041b1d70f5af8a.

This prevents inconsistencies between the two representations of the
operation; the current code just avoided them by being careful.
