### PR TITLE
Recover performance by disabling debug

### DIFF
--- a/pts.cabal
+++ b/pts.cabal
@@ -20,6 +20,11 @@ Source-Repository head
   location:            git://github.com/Toxaris/pts.git
   branch:              master
 
+Flag debug-typing
+  Description:         Enable the --debug=typing flag.
+  Default:             False
+  Manual:              True
+
 Library
   Hs-source-dirs:      src-lib
   Build-depends:       base < 5,
@@ -68,6 +73,9 @@ Library
   -- Flags useful for heap profiling. They might be redundant with
   -- --enable-library-profiling.
   -- Ghc-options: -fprof-auto -fno-prof-count-entries
+
+  if flag(debug-typing)
+    CPP-Options: -DDEBUG_TYPING
 
 Executable pts
   Hs-source-dirs:      src-exec

--- a/src-lib/Control/Monad/Log.hs
+++ b/src-lib/Control/Monad/Log.hs
@@ -52,7 +52,6 @@ instance MonadState s m => MonadState s (ConsoleLogT m) where
   put s = ConsoleLogT (lift (put s))
 
 instance MonadIO m => MonadLog (ConsoleLogT m) where
-{-
   enter text = do
     (enabled, trace) <- ConsoleLogT $ get
     log $ " >>> " ++ text
@@ -71,10 +70,7 @@ instance MonadIO m => MonadLog (ConsoleLogT m) where
     (enabled, trace) <- get
     when enabled $
       liftIO $ putStrLn $ replicate (length trace) '-' ++ " " ++ text
--}
-  enter _ = return ()
-  exit = return ()
-  log _ = return ()
+
   stacktrace = ConsoleLogT $ do
     (_, trace) <- get
     return trace

--- a/src-lib/PTS/Options.hs
+++ b/src-lib/PTS/Options.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ExistentialQuantification, FlexibleContexts, RankNTypes, ScopedTypeVariables #-}
+{-# LANGUAGE CPP #-}
 module PTS.Options where
 
 import Control.Monad (when)
@@ -23,7 +24,9 @@ data Options = Options
   , optLiterate :: Bool
   , optShowFullTerms :: Bool
   , optDebugQuote :: Bool
+#ifdef DEBUG_TYPING
   , optDebugType :: Bool
+#endif
   , optQuiet :: Bool
   , optPath :: [FilePath]
   }
@@ -42,17 +45,27 @@ defaultOptions = Options
   , optLiterate = False
   , optShowFullTerms = False
   , optDebugQuote = False
+#ifdef DEBUG_TYPING
   , optDebugType = False
+#endif
   , optQuiet = False
   , optPath = ["."]
   }
+
+#ifndef DEBUG_TYPING
+optDebugType :: Options -> Bool
+optDebugType _ = False
+#endif
+
 
 setColumns    x options = options {optColumns = x}
 setInstance   x options = options {optInstance = x}
 setLiterate   x options = options {optLiterate = x}
 setDebugTerms x options = options {optShowFullTerms = x}
 setDebugQuote x options = options {optDebugQuote = x}
+#ifdef DEBUG_TYPING
 setDebugType  x options = options {optDebugType = x}
+#endif
 setQuiet      x options = options {optQuiet = x}
 setPath       x options = options {optPath = x}
 
@@ -104,9 +117,14 @@ handleLiterate arg = case fmap (map toLower) arg of
 
 handleDebug arg    = case map toLower arg of
                        "toplevel"    -> Local  (setDebugTerms True       )
-                       "typing"      -> Local  (setDebugType  True       )
                        "quoting"     -> Local  (setDebugQuote True       )
+#ifdef DEBUG_TYPING
+                       "typing"      -> Local  (setDebugType  True       )
                        _             -> Error  ("Error: debug option expects 'toplevel', 'typing' or 'quoting' instead of " ++ arg)
+#else
+                       "typing"      -> Error  ("Error: this version of PTS was compiled without support for --debug=typing")
+                       _             -> Error  ("Error: debug option expects 'toplevel' or 'quoting' instead of " ++ arg)
+#endif
 
 handleQuiet        = Global (setQuiet True)
 

--- a/src-lib/PTS/Statics/Typing.hs
+++ b/src-lib/PTS/Statics/Typing.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoMonomorphismRestriction, FlexibleContexts, PatternGuards, FlexibleInstances #-}
+{-# LANGUAGE CPP #-}
 module PTS.Statics.Typing where
 
 import Prelude (fst, snd, String)
@@ -96,8 +97,9 @@ safebind x t b f = do
 
 debug :: (MonadEnvironment Name (Binding Eval) m, MonadLog m) => String -> Term -> m TypedTerm -> m TypedTerm
 debug n t result = do
+#ifndef LOGGING
   result
-  {-
+#else
   enter n
   ctx <- getEnvironment
   -- log $ "Context: " ++ showCtx [(n, (x, y)) | (n, (_, x, y)) <- ctx]
@@ -107,12 +109,13 @@ debug n t result = do
   log $ "         : " ++ showPretty (typeOf x)
   exit
   return x
-  -}
+#endif
 
 debugPush :: (MonadEnvironment Name (Binding Eval) m, MonadLog m) => String -> Term -> TypedTerm -> m TypedTerm -> m TypedTerm
 debugPush n t q result = do
+#ifndef LOGGING
   result
-  {-
+#else
   enter n
   ctx <- getEnvironment
   log $ "Context: " ++ showCtx [(n, (x, y)) | (n, (_, x, y)) <- ctx]
@@ -123,7 +126,7 @@ debugPush n t q result = do
   log $ "         : " ++ showPretty (typeOf x)
   exit
   return x
-  -}
+#endif
 
 
 -- error messages and generic error checking
@@ -228,7 +231,9 @@ typecheckPull t = case structure t of
 
   Var x -> debug "typecheckPull Var" t $ do
     ctx <- getEnvironment
+#ifdef LOGGING
     log $ "Context: " ++ showCtx [(n, (x, y)) | (n, (_, x, y)) <- ctx]
+#endif
     xt <- lookupType x
     case xt of
       Just xt -> do


### PR DESCRIPTION
With profiling, this goes from 20 to 6 seconds. Without profiling, I've
seen something like from 6 to 2 seconds.

Feel free to reenable this code if you figure out how to make it cheap.
