### PR TITLE
Unbox name components.

### DIFF
--- a/src-lib/PTS/QuasiQuote.hs
+++ b/src-lib/PTS/QuasiQuote.hs
@@ -82,8 +82,8 @@ instance Lift C where
   lift (C n) = con 'C [lift n]
 
 instance Lift Name where
-  lift (PlainName  s)    = con 'PlainName [lift s]
-  lift (IndexName  i s)  = con 'IndexName [lift i, lift s]
+  lift (PlainName  c s)    = con 'PlainName [lift c, lift s]
+  lift (IndexName  i c s)  = con 'IndexName [lift i, lift c, lift s]
   lift (MetaName s)      = var (TH.mkName s)
 
 instance Lift Term where

--- a/src-lib/PTS/Syntax/Names.hs
+++ b/src-lib/PTS/Syntax/Names.hs
@@ -20,27 +20,28 @@ parts :: ModuleName -> [String]
 parts (ModuleName xs) = xs
 
 data Name
-  = PlainName String
-  | IndexName Int String
+  = PlainName {-# UNPACK #-} !Char String
+  | IndexName {-# UNPACK #-} !Int {-# UNPACK #-}!Char String
   | MetaName String
   deriving (Eq, Ord, Data, Typeable)
 
 type Names = Set Name
 
 instance Show Name where
-  showsPrec _ (PlainName text) = showString text
-  showsPrec _ (IndexName i text) = showString text . shows i
+  showsPrec _ (PlainName c text) = showString (c : text)
+  showsPrec _ (IndexName i c text) = showString (c : text) . shows i
   showsPrec _ (MetaName text) = showChar '$' . showString text
 
 instance Read Name where
-  readsPrec _ (c:cs) | isLetter c = [plainName [c] cs] where
+  readsPrec _ (first:cs) | isLetter first = [plainName [] cs] where
     plainName text (c:cs) | isDigit c = indexName text [c] cs
     plainName text (c:cs) | isAlphaNum c = plainName (c : text) cs
-    plainName text rest = (PlainName (reverse text), rest)
+    plainName text rest = (PlainName first (reverse text), rest)
 
     indexName text index (c:cs) | isDigit c = indexName text (c : index) cs
     indexName text index (c:cs) | isAlphaNum c = plainName (index ++ text) cs
-    indexName text index rest = (IndexName (read (reverse index)) (reverse text), rest)
+    indexName text index rest = (IndexName (read (reverse index)) first (reverse text), rest)
+
 
   readsPrec _ ('$':c:cs) | isLower c = [metaName [c] cs] where
     metaName text (c:cs) | isAlphaNum c = metaName (c : text) cs
@@ -49,8 +50,8 @@ instance Read Name where
   readsPrec _ _ = []
 
 nextIndex :: Name -> Name
-nextIndex (PlainName text) = IndexName 0 text
-nextIndex (IndexName index text) = IndexName (index + 1) text
+nextIndex (PlainName char text) = IndexName 0 char text
+nextIndex (IndexName index char text) = IndexName (index + 1) char text
 
 freshvarl :: Names -> Name -> Name
 freshvarl xs x


### PR DESCRIPTION
This improves the memory layout of names and the generated Eq and Ord instances and thereby speeds up pts by ca. 13% for me.
