### PR TITLE
Improve defaults for find-tag.

### DIFF
--- a/emacs/pts-mode.el
+++ b/emacs/pts-mode.el
@@ -148,7 +148,7 @@ data if you want to preserve them."
   (let ((old-point (point)))
     (save-excursion
       (beginning-of-line)
-      (and (search-forward-regexp "\\=\\(?:> \\)?import\\s-+\\(\\w+\\(?:\\.\\w+\\)*\\)\\s-+\\(;\\|$\\)" nil t)
+      (and (search-forward-regexp "\\=\\(?:> \\)?import\\s-+\\(\\w+\\(?:\\.\\w+\\)*\\)\\s-*\\(;\\|$\\)" nil t)
            (<= old-point (point))
            (match-string 1)))))
 


### PR DESCRIPTION
Provide better defaults for <kbd>M-.</kbd> (find-tag) that allow easy jumping to imported modules. Also some sanity-checking on the defaults to avoid searching for keywords.
