### PR TITLE
Fix #97: typecheckPush succeeds too often on Const

### DIFF
--- a/src-lib/PTS/Statics/Typing.hs
+++ b/src-lib/PTS/Statics/Typing.hs
@@ -346,7 +346,8 @@ typecheckPush t q = case structure t of
   Const c -> debugPush "typecheckPush Const" t q $ do
     pts <- asks optInstance
     case axioms pts c of
-      Just t  ->  return (MkTypedTerm (Const c) t)
+      Just ct -> do bidiExpected ct q t "Attempted to push the wrong type onto a constant."
+                    return (MkTypedTerm (Const c) ct)
       _       ->  prettyFail $ text "Unknown constant:" <+> pretty 0 c
 
   Var x -> debugPush "typecheckPush Var" t q $ do


### PR DESCRIPTION
This is the fix we reviewed today.
This will break code in Toxaris/tsr-experiments (in minor ways), so probably fix them first.
