### PR TITLE
Avoid local options v2

### DIFF
--- a/src-lib/PTS/Options.hs
+++ b/src-lib/PTS/Options.hs
@@ -203,8 +203,8 @@ locateEmacsMode = do
 render n = renderStyle (Style PageMode n 1)
 
 -- main entry point
-parseCommandLine :: (Functor m, MonadIO m) => (Options -> [FilePath] -> m a) -> m a
-parseCommandLine handler = do
+parseCommandLine :: (Functor m, MonadIO m) => m (Options, [FilePath])
+parseCommandLine = do
   cmdline <- liftIO getArgs
   let (flags, fileNames, errors) = getOpt Permute options cmdline
   mapM_ (fail . ("Syntax Error in command line: " ++)) errors
@@ -213,4 +213,4 @@ parseCommandLine handler = do
   processFlagsLocateEmacsMode flags
   processFlagsShowInsts flags
   flags <- processFlags defaultOptions flags
-  handler flags fileNames
+  return (flags, fileNames)

--- a/src-lib/PTS/Process/Main.hs
+++ b/src-lib/PTS/Process/Main.hs
@@ -25,7 +25,8 @@ import System.Exit (exitSuccess, exitFailure)
 import System.IO (hPutStrLn, stderr, hFlush, stdout)
 
 main = do
-  result <- parseCommandLine processJobs
+  (opts, files) <- parseCommandLine
+  result <- processJobs opts files
   processErrors result
 
 processErrors result = do


### PR DESCRIPTION
Fixes #55, by removing local options and simplifying option handling as much as I can see.
