### PR TITLE
Arguments of keyword must show up in keywords

### DIFF
--- a/src-lib/PTS/Syntax/Parser.hs
+++ b/src-lib/PTS/Syntax/Parser.hs
@@ -168,7 +168,7 @@ pragma = lexem $ do
     -- LEXER --
      ---------
 
-keywords = ["Lambda", "lambda", "Pi", "if0", "then", "else", "->", "add", "mul", "sub", "div", "module", "import", "export", "assert", "language"]
+keywords = ["Lambda", "lambda", "Pi", "if0", "then", "else", "->", "add", "mul", "sub", "div", "module", "import", "export", "assert", "language", "_("]
 
 identChar x = not (isSpace x) && x `notElem` ".:=;/()[]$"
 
@@ -229,7 +229,8 @@ const = lexem (do name <- many1 (satisfy identChar)
                       else pzero)
           <?> "constant"
 
-keyword s  = lexem (string s <* notFollowedBy (satisfy identChar))
+keyword s | s `elem` keywords = lexem (string s <* notFollowedBy (satisfy identChar))
+keyword s  = error $ "Keyword '" ++ s ++ "' not in keywords"
 
 comment = string "/*" <* manyTill anyChar (try (string "*/"))
 


### PR DESCRIPTION
It seems there's an invariant (the argument of `keyword` must show up in
`keywords`) which is not enforced. Let's enforce that dynamically by
calling `error` on violations: this is triggered during tests often
enough (for each keyword call which is covered, but coverage seems good
enough), so violations are triggered before deployment often enough.

The runtime overhead is not noticeable, since parsing time is overall
minimal.

See violation of this in:
https://github.com/Blaisorblade/pts/commit/b73eb5c1fdc6fab1e11b6349aee2471fd133266f#commitcomment-7509176

Also fix another violation which remained here: `_(` was not a keyword,
and this was detected during testing.
