### PR TITLE
Travis: run all tests in allTests.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ cache:
   directories:
   - ~/.cabal
   - ~/.ghc
+script:
+  - ./mostTests.sh
+  - cabal install dist/*.tar.gz --enable-tests

--- a/allTests.sh
+++ b/allTests.sh
@@ -1,18 +1,5 @@
 #!/bin/sh -x
-[ -z "$CABAL" ] && CABAL=cabal
-
-set -e
-
-$CABAL clean
-$CABAL check
-
-$CABAL install --only-dependencies --enable-tests
-$CABAL configure --enable-tests
-$CABAL build
-
-$CABAL sdist
-
-dist/build/tests/tests --hide-successes --maximum-generated-tests=10000 --maximum-unsuitable-generated-tests=10000 --jxml=junit-log.xml
+. mostTests.sh
 
 nameBase=`runhaskell src-tools/package-info.hs --package`
 $CABAL install dist/$nameBase.tar.gz --enable-tests

--- a/mostTests.sh
+++ b/mostTests.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -x
+[ -z "$CABAL" ] && CABAL=cabal
+
+set -e
+
+rm -rf dist
+$CABAL clean
+$CABAL check
+
+$CABAL install --only-dependencies --enable-tests
+$CABAL configure --enable-tests
+$CABAL build
+
+$CABAL sdist
+
+dist/build/tests/tests --hide-successes --maximum-generated-tests=10000 --maximum-unsuitable-generated-tests=10000 --jxml=junit-log.xml

--- a/pts.cabal
+++ b/pts.cabal
@@ -13,6 +13,7 @@ Extra-source-files:  examples/Arithmetics.lpts
                      examples/ChurchNumbers.lpts
                      examples/Functions.lpts
                      examples/Inference.lpts
+                     examples/Syntax.lpts
 Data-files:          emacs/pts-mode.el
 Cabal-version:       >= 1.8
 


### PR DESCRIPTION
- Since `runhaskell src-tools/package-info.hs --package` doesn't quite work on Travis, and fixing that is *hard*, use `*` instead to find the path to the tarball.
- Also, fix the one error which is caught by this testing — a missing file in the source distro.