### PR TITLE
Minor cleanup from Travis branch

### DIFF
--- a/src-tools/package-info.hs
+++ b/src-tools/package-info.hs
@@ -3,9 +3,9 @@
 
 import Prelude hiding (print)
 
-import Distribution.Simple
-import Distribution.Simple.LocalBuildInfo
-import Distribution.Simple.Configure
+import Distribution.Simple (packageId, pkgName, pkgVersion)
+import Distribution.Simple.LocalBuildInfo (LocalBuildInfo, localPkgDescr)
+import Distribution.Simple.Configure (getPersistBuildConfig)
 import Distribution.Text
 import System.Environment
 

--- a/src-tools/package-info.hs
+++ b/src-tools/package-info.hs
@@ -5,14 +5,12 @@ import Prelude hiding (print)
 
 import Distribution.Simple
 import Distribution.Simple.LocalBuildInfo
+import Distribution.Simple.Configure
 import Distribution.Text
 import System.Environment
 
 readLocalBuildInfo :: IO LocalBuildInfo
-readLocalBuildInfo = do
-  text <- readFile "dist/setup-config"
-  let body = dropWhile (/= '\n') text
-  return (read body)
+readLocalBuildInfo = getPersistBuildConfig "dist"
 
 print :: Text a => a -> IO ()
 print x = putStrLn (display x)


### PR DESCRIPTION
Cleanups for package-info.hs.

They make it fail earlier if there's a mismatch in the used version of the Cabal library.