### PR TITLE
Support GHC 7.10.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 #*#
 *~
 dist/*
-
+.cabal-sandbox
+cabal.sandbox.config

--- a/pts.cabal
+++ b/pts.cabal
@@ -37,8 +37,8 @@ Library
   Build-depends:       base < 5,
                        containers >= 0.4 && < 0.6,
                        pretty >= 1.0 && < 1.2,
-                       mtl >= 2.0 && < 2.2,
-                       transformers >= 0.2 && < 0.4,
+                       mtl >= 2.0 && < 2.3,
+                       transformers >= 0.2 && < 0.5,
                        parsec == 3.1.*,
                        template-haskell,
                        syb,
@@ -129,8 +129,8 @@ Test-suite tests
                        PTS.Syntax.Substitution.Tests
                        Test.Property
   Build-depends:       base >= 4.0 && < 5,
-                       mtl >= 2.0 && < 2.2,
-                       transformers >= 0.2 && < 0.4,
+                       mtl >= 2.0 && < 2.3,
+                       transformers >= 0.2 && < 0.5,
                        containers >= 0.4 && < 0.6,
                        pretty >= 1.0 && < 1.2,
                        test-framework,

--- a/src-lib/PTS/Dynamics/TypedTerm.hs
+++ b/src-lib/PTS/Dynamics/TypedTerm.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, GADTs, UndecidableInstances #-}
+{-# LANGUAGE MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, GADTs, UndecidableInstances #-}
 module PTS.Dynamics.TypedTerm
   ( TypedTerm
   , typeOf

--- a/src-lib/PTS/Error.hs
+++ b/src-lib/PTS/Error.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoMonomorphismRestriction, FlexibleInstances, TypeSynonymInstances, DeriveDataTypeable #-}
+{-# LANGUAGE NoMonomorphismRestriction, FlexibleContexts, FlexibleInstances, TypeSynonymInstances, DeriveDataTypeable #-}
 module PTS.Error
   ( Errors
   , PTSError (..)

--- a/src-lib/PTS/Syntax/Term.hs
+++ b/src-lib/PTS/Syntax/Term.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE NoMonomorphismRestriction, DeriveFunctor, DeriveDataTypeable, StandaloneDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies, FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies, FlexibleContexts, FlexibleInstances #-}
 module PTS.Syntax.Term
   ( Term (..)
   , AnnotatedTerm


### PR DESCRIPTION
The next step would be dealing with the following:
```
src-lib/Control/Monad/Errors/Class.hs:18:21: Warning:
    In the use of type constructor or class ‘Error’
    (imported from Control.Monad.Error.Class, but defined in Control.Monad.Trans.Error):
    Deprecated: "Use Control.Monad.Trans.Except instead"
```
```
src-lib/Control/Monad/Errors.hs:7:1: Warning:
    Module ‘Control.Monad.Error’ is deprecated:
      Use Control.Monad.Except instead
```